### PR TITLE
master branch contains all leslie changes

### DIFF
--- a/examples/improver/tweet_summary.rb
+++ b/examples/improver/tweet_summary.rb
@@ -1,0 +1,73 @@
+
+#
+# Stupidly simple class for holding a twitter user's tweet summary
+#
+class UserTweetSummary  
+  attr_accessor :fields
+
+  def initialize fields
+    @fields = fields    
+  end
+    
+  def update tweets
+    deletes_this_batch = 0
+    tweets_this_batch  = 0
+    tweets.each do |tweet|
+      deletes_this_batch += (tweet.is_deleted ? 1 : 0)
+      tweets_this_batch  += 1
+    end
+    fields['deletes'] += deletes_this_batch
+    fields['tweets']  += (tweets_this_batch - deletes_this_batch)
+    self
+  end
+
+  def to_json *args
+    fields.to_json     
+  end  
+end
+
+#
+# Holds a tweet and whether
+# or not it's been deleted
+#
+class Tweet
+  attr_accessor :is_deleted
+  def initialize hash
+    @is_deleted = hash.keys.include?("delete")
+  end
+end
+
+
+#
+# Improver processor
+#
+class TweetSummarizer < Wukong::Processor::Improver
+  attr_accessor :user_id
+  
+  def zero
+    super
+    {
+      'tweets'  => 0,
+      'deletes' => 0
+    }
+  end
+
+  def accumulate record
+    @user_id = record[0]
+    json     = record[1]
+    self.group << Tweet.new(JSON.parse(json))
+  end
+
+  def improve summary, deltas    
+    UserTweetSummary.new(JSON.parse(summary)).update(deltas)
+  end  
+end
+
+#
+# Is this necessary?
+#
+TweetSummarizer.register(:tweet_summarizer)
+
+Wukong.dataflow(:summarize_tweets) do
+  tweet_summarizer | to_json
+end

--- a/lib/wukong/widget/reducers.rb
+++ b/lib/wukong/widget/reducers.rb
@@ -1,4 +1,5 @@
 require_relative("reducers/accumulator")
+require_relative("reducers/improver")
 require_relative("reducers/sort")
 require_relative("reducers/count")
 require_relative("reducers/group")

--- a/lib/wukong/widget/reducers/improver.rb
+++ b/lib/wukong/widget/reducers/improver.rb
@@ -1,0 +1,63 @@
+module Wukong
+  class Processor
+
+    # A base widget for building more complex improver widgets.
+    class Improver < Processor
+
+      # The current group of records.
+      attr_accessor :group
+
+      # Sets up this improver by defining an initial key (with a
+      # value that is unlikely to be found in real data) and calling
+      # `#zero` with no record.
+      def setup
+        @key = :__first_group__
+        zero
+      end
+
+      def recordize record
+        record.split("\t")
+      end
+      
+      #
+      # All kinds of assumptions here,
+      # record is tab-delimited and the
+      # first field is a name of a function
+      # to call
+      #
+      def get_function record
+        record.first
+      end
+      
+      # Processes the `record`.
+      def process(record)
+        fields = recordize(record)
+        func   = get_function(fields)
+        case func
+        when 'zero' then
+          yield zero
+        when 'accumulate' then
+          accumulate(fields[1..-1])
+        when 'improve' then
+          yield improve(fields.first, self.group)
+          self.group = []
+        else
+          raise NoMethodError, "undefined method #{func} for Improver"
+        end
+      end
+
+      # Starts accumulation for a new key. Return what you would
+      # with no improvements.
+      def zero
+        self.group = []
+      end
+
+      # Accumulates another +record+.
+      #
+      # @param [Object] record
+      def accumulate record
+        self.group << record
+      end
+    end
+  end
+end

--- a/lib/wukong/widget/reducers/improver.rb
+++ b/lib/wukong/widget/reducers/improver.rb
@@ -39,11 +39,12 @@ module Wukong
         when 'accumulate' then
           accumulate(fields[1..-1])
         when 'improve' then
-          yield improve(fields.first, self.group)
+          yield improve(fields[1], self.group)
           self.group = []
         else
           raise NoMethodError, "undefined method #{func} for Improver"
         end
+        STDOUT.flush # WHY? Because.
       end
 
       # Starts accumulation for a new key. Return what you would
@@ -58,6 +59,13 @@ module Wukong
       def accumulate record
         self.group << record
       end
+
+      # Improve prev with group
+      #
+      #
+      def improve prev, group
+      end
+      
     end
   end
 end


### PR DESCRIPTION
The head of master and leslie should be now identical (leslie rebased onto master)

interesting commits (oldest first):
    \* 69cf15 - common ancestor of leslie and master branches (Feb 2012)
    \* 550e21 - old master HEAD (Nov 2012)
    \* 516b8f - single commit which reverts everything between 69cf15 and 550e21 (revert to common ancestor)
    \* 418 commits following 516b8f - rebase of leslie onto master
