### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ cat novel.txt | wu-local string_reverser.rb
 .semit fo tsrow eht saw ti ,semit fo tseb eht saw tI
 ```
 
-The `wu-local` program consumes one line at at time from STDIN and
+The `wu-local` program consumes one line at a time from STDIN and
 calls your processor's `process` method with that line as a Ruby
 String object.  Each object you `yield` within your process method
 will be printed back out on STDOUT.

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ options `--to` and `--from` on the command-line, as <a
 href="#serialization">defined above</a>.
 
 For processors which will only run inside a data flow, you can
-optimize by not doing any (de)serialization until except at the very
+optimize by not doing any (de)serialization except at the very
 beginning and at the end
 
 ```ruby


### PR DESCRIPTION
Just fixing a couple typos I found in the README
